### PR TITLE
Update config/database.yml.example and create config/database.yml.travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ services:
   - elasticsearch
 
 before_script:
-  - cp config/database.yml.template config/database.yml
-  - sleep 10
+  - cp config/database.yml.travis config/database.yml
 
 script:
   - RAILS_ENV=test bundle exec rake db:setup --trace

--- a/config/database.yml.template
+++ b/config/database.yml.template
@@ -15,7 +15,7 @@ default: &default
   pool: 5
   username: root
   password:
-  host:
+  host: db
   port: 3306
 
 development:

--- a/config/database.yml.travis
+++ b/config/database.yml.travis
@@ -1,0 +1,9 @@
+test:
+  adapter: mysql2
+  encoding: utf8
+  pool: 5
+  username: root
+  password:
+  host:
+  port: 3306
+  database: peba_test


### PR DESCRIPTION
In order to set `config/database.yml.example` properly to be used with docker out of box it must use `db` as a hostname for database.

Because of that I created the file `config/database.yml.travis` to be used in CI.