### PR TITLE
Mostra a logo do Peba ao invés do nome no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-=====
-PEBA
-=====
+![PEBA](https://github.com/teresinahc/peba/raw/master/app/assets/images/peba_logo.png)
 
 <a href="https://travis-ci.org/teresinahc/peba" target="_blank">
 	<img src="https://travis-ci.org/teresinahc/peba.svg?branch=master" alt="Build Status">


### PR DESCRIPTION
Mostra a logo do Peba ao invés do nome no README (como a maioria dos README's de projetos FOSS)